### PR TITLE
Add necessary keys from docker env to env example and remove old

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ SENTRY_DSN=
 TEST_APP_PORT=9949
 
 TEST_DB_PORT=5433
-TEST_DB_HOST=pg_test
+TEST_DB_HOST=localhost
 TEST_DB_NAME=express_test
 TEST_DB_USER=postgres
 TEST_DB_PASSWORD=mysecretpassword

--- a/.env.example
+++ b/.env.example
@@ -1,34 +1,35 @@
 # Application
-APP_NAME='Sample API'
-APP_VERSION='1.0.0'
-APP_PORT='8848'
-APP_HOST='127.0.0.1'
+APP_NAME=API Code Compass
+APP_VERSION=1.0.0
+APP_PORT=8848
+APP_HOST=0.0.0.0
 
 # Log
-LOG_LEVEL='debug'
+LOGGING_DIR=logs
+LOGGING_LEVEL=debug
 
 # Database
-DB_CLIENT='pg'
+DB_CLIENT=pg
 
 # App Environment
-DB_PORT='5432'
-DB_HOST='localhost'
-DB_NAME='express'
-DB_USER='username'
-DB_PASSWORD='password'
+DB_PORT=5432
+DB_HOST=pg
+DB_NAME=express
+DB_USER=postgres
+DB_PASSWORD=mysecretpassword
 
 # Sentry
 # https://docs.sentry.io/quickstart
-SENTRY_DSN=''
+SENTRY_DSN=
 
 # Test Environment
-TEST_APP_PORT='9949'
-TEST_DB_PORT='5433'
-TEST_DB_HOST='localhost'
-TEST_DB_NAME='express_test'
-TEST_DB_USER='username'
-TEST_DB_PASSWORD='password'
+TEST_APP_PORT=9949
 
-#JWT SECRET
-ACCESS_TOKEN_SECRET="your_access_token_secret"
-REFRESH_TOKEN_SECRET="your_refresh_token_secret"
+TEST_DB_PORT=5433
+TEST_DB_HOST=pg_test
+TEST_DB_NAME=express_test
+TEST_DB_USER=postgres
+TEST_DB_PASSWORD=mysecretpassword
+
+ACCESS_TOKEN_SECRET='your_access_token_secret'
+REFRESH_TOKEN_SECRET='your_refresh_token_secret'

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Example,
 
 Use [docker-compose](https://docs.docker.com/compose/) to quickly bring up a stack with pre-configured Postgres database container. Data is ephemeral and containers will disappear when stack is removed.
 
-Specific configuration for Docker is in `.env.docker`
+Update `.env` file accordingly.
 
 - `0.0.0.0` as `$APP_HOST` to expose app on Docker network interface
 - Pre-configured Postgres settings - can be updated to point to another Postgres host


### PR DESCRIPTION
## Describe your changes

It was causing local issue due to older .env which is different than from .env.docker
Now there won't be docker specific env which caused confusion. It shall use the same .env for local and docker runs

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have created postman test scripts for it

## Postman Screenshots


## Postman pull request URL
